### PR TITLE
Migrate from deprecated API

### DIFF
--- a/src/synergix/plugin/intellj/wm/SynergixScreensPanel.java
+++ b/src/synergix/plugin/intellj/wm/SynergixScreensPanel.java
@@ -48,7 +48,7 @@ public class SynergixScreensPanel extends SimpleToolWindowPanel implements DataP
 	private void buildTree() {
 		SynergixScreensBuilder treeBuilder = new SynergixScreensBuilder(this.myProject);
 		SynergixScreensStructure myScreenStructure = treeBuilder.getMyTreeStructure();
-		final StructureTreeModel treeModel = new StructureTreeModel<>(myScreenStructure);
+		final StructureTreeModel treeModel = new StructureTreeModel<>(myScreenStructure, this);
 		this.myTree = new Tree(new AsyncTreeModel(treeModel, this));
 
 		this.myTree.setRootVisible(true);


### PR DESCRIPTION
`com.intellij.ui.tree.StructureTreeModel#StructureTreeModel(Structure)` was deprecated in May and will be removed now. This change migrates to the recommended one. I did not run checks for this change, please test it before merging.